### PR TITLE
[v1.0] Implement the de/serialization of a ChatMessage bytes buffer

### DIFF
--- a/Client/ClientProgram.cs
+++ b/Client/ClientProgram.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
-using Castle.Core.Internal;
 using Shared;
 
 namespace Client {
@@ -28,7 +27,7 @@ namespace Client {
         /// <summary>
         /// The user's custom nickname (mandatory).
         /// </summary>
-        private static string nickname;
+        private static string _nickname;
 
         /// <summary>
         /// Prints the usage of this program.
@@ -78,14 +77,25 @@ namespace Client {
         public static string Prompt(string promptMessage, int maximalLength) {
             var readString = string.Empty;
 
-            while (readString.IsNullOrEmpty() || readString.Length > maximalLength) {
+            while (readString?.Length < 1 || readString?.Length > maximalLength) {
                 Console.Write(promptMessage);
-                readString = Console.ReadLine();  // TODO: strip the message
+                readString = Console.ReadLine()?.Trim();
             }
 
             return readString;
         }
 
+        /// <summary>
+        /// Prompt the user to enter a "valid" <see cref="Command"/>.
+        ///
+        /// Note that a non existing <see cref="Command"/> <see cref="Int32"/> value is still
+        /// taken as a valid value. But only a bad <see cref="String"/> name is detected.
+        ///
+        /// If a <see cref="Int32"/> value is passed, it will be cased later on by
+        /// <see cref="ChatMessage"/> to a <see cref="Byte"/>.
+        /// </summary>
+        ///
+        /// <returns>The submitted command.</returns>
         public static Command PromptCommand() {
             while (true) {
                 var inputCommand = Prompt("Command (POST, GET, SUB or UNSUB): ", 10).ToUpper();
@@ -108,7 +118,7 @@ namespace Client {
             return new ChatMessage(
                 command: command,
                 type: CommandType.REQUEST,
-                nickname: nickname,
+                nickname: _nickname,
                 data: message);
         }
 
@@ -123,7 +133,7 @@ namespace Client {
             }
 
             // Prompt for a nickname
-            nickname = Prompt(
+            _nickname = Prompt(
                 "Nickname: ", ChatMessage.MAX_NICKNAME_SIZE - 1);  // The maximal nickname length, excluding NUL
 
             // Log the server endpoint that we are going to use,

--- a/Doxyfile
+++ b/Doxyfile
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "Urbanotopus"
+PROJECT_NAME           = "Topiscuss"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
@@ -454,7 +454,7 @@ EXTRACT_PACKAGE        = NO
 # included in the documentation.
 # The default value is: NO.
 
-EXTRACT_STATIC         = NO
+EXTRACT_STATIC         = YES
 
 # If the EXTRACT_LOCAL_CLASSES tag is set to YES, classes (and structs) defined
 # locally in source files will be included in the documentation. If set to NO,

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ The project uses `doxygen` to compile the internal C# XML documentation.
 ### Installing Doxygen
 | Platform   | Version   | Reason                                           |
 |------------|-----------|--------------------------------------------------|
-| Windows(*) | == 1.8.0  | Other releases are bugged on Windows.            |
-| Unix-like  | \>= 1.8.0 | All versions are working just fine on Unix-like. |
+| Windows(*) | \>= 1.8.8 | Previous releases are bugged on Windows.         |
+| Unix-like  | \>= 1.8.4 | All versions are working just fine on Unix-like. |
 
 <p align='center'>
-    <a href='https://is.gd/2FVTMA'>Windows Download Link</a>
+    <a href='https://is.gd/q59nvx'>Windows Download Link</a>
 </p>
 
 Note: on Windows, add `doxygen` to your `PATH`.

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -1,9 +1,68 @@
 ﻿using System;
+using System.Net;
+using System.Net.Sockets;
+using Shared;
 
 namespace Server {
     internal static class Program {
-        private static void Main(string[] args) {
-            Console.WriteLine("Hello World!");
+        /// <summary>
+        /// The server socket from which we will bind ourselves and listen for incoming messages.
+        /// </summary>
+        private static Socket _serverSocket;
+
+        /// <summary>
+        /// Handle a received message from a given client.
+        /// </summary>
+        /// <param name="chatMessage">The message to handle.</param>
+        /// <param name="clientEndpoint">The client endpoint that the message came from.</param>
+        private static void HandleMessage(ChatMessage chatMessage, EndPoint clientEndpoint) {
+            Console.WriteLine("[{0}]{1}", clientEndpoint, chatMessage);
+        }
+
+        /// <summary>
+        /// Listens for messages and handle them.
+        /// </summary>
+        private static void ProcessMessages() {
+            // Create a IP address endpoint to store the client information into
+            EndPoint clientEndpoint = new IPEndPoint(IPAddress.Any, 0);
+
+            // Wait for a message and retrieve it
+            var buffer = new byte[ChatMessage.FINAL_BUFFER_MAX_SIZE];
+            _serverSocket.ReceiveFrom(buffer, buffer.Length, SocketFlags.None, ref clientEndpoint);
+
+            try {
+                // Decode the received buffer and handle the received message
+                HandleMessage(new ChatMessage(buffer), clientEndpoint);
+            }
+            catch (NULTerminationNotFound) {
+                Console.WriteLine("Error: received invalid message.");
+            }
+        }
+
+        /// <summary>
+        /// Entry point for the UDP <see cref="Server"/>, it opens a socket
+        /// and handles every incoming messages.
+        /// </summary>
+        private static void Main() {
+            // Create the listening UDP socket
+            _serverSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+
+            try {
+                // Bind the server socket to the default config
+                _serverSocket.Bind(new IPEndPoint(IPAddress.Any, DefaultConfig.DEFAULT_SERVER_PORT));
+                Console.WriteLine("Now listening on {0}...", _serverSocket.LocalEndPoint);
+
+                // Process every incoming messages
+                while (true) {
+                    ProcessMessages();
+                }
+            }
+            catch (SocketException exc) {
+                Console.WriteLine(exc.Message);
+            }
+            finally {
+                _serverSocket.Close();
+            }
         }
     }
 }

--- a/Server/ServerProgram.cs
+++ b/Server/ServerProgram.cs
@@ -61,6 +61,7 @@ namespace Server {
                 Console.WriteLine(exc.Message);
             }
             finally {
+                // Finally, close the server socking that we were listening on
                 _serverSocket.Close();
             }
         }

--- a/Shared/ByteUtils.cs
+++ b/Shared/ByteUtils.cs
@@ -1,0 +1,61 @@
+using System.Data;
+using System.Text;
+
+namespace Shared {
+    /// <inheritdoc />
+    /// <summary>
+    /// An exception that occurs when looking for a <code>NUL termination</code>, but none is found.
+    /// </summary>
+    public class NULTerminationNotFound : SyntaxErrorException {}
+
+    public class ByteUtils {
+        /// <summary>
+        /// Parse a string from a given bytes buffer, starting from a given point
+        /// until a <code>NUL termination</code> is found.
+        /// Throws an exception if the max byte count was reached without finding any NUL terminated string.
+        /// </summary>
+        ///
+        /// <param name="buffer">The buffer of bytes to read from.</param>
+        /// <param name="startIndex">The index to start looking from.</param>
+        /// <param name="maxCount">The maximum byte count to look into.</param>
+        /// <param name="foundString">The variable to store the parsed string into, if successfully parsed.</param>
+        ///
+        /// <returns>
+        /// The position of the <code>NUL termination</code> if any
+        /// (<see cref="NULTerminationNotFound"/> is thrown otherwise).
+        /// </returns>
+        ///
+        /// <exception cref="NULTerminationNotFound">
+        /// Thrown if it was unable to find a <code>NUL termination</code> in the given range.
+        /// </exception>
+        public static ushort GetNulTerminatedString(
+                byte[] buffer, ushort startIndex, ushort maxCount, out string foundString) {
+
+            // Initialize the current count of bytes read to zero
+            var currentCount = 0;
+
+            // Initialize the cursor position to the given start index
+            var currentPos = startIndex;
+
+            // Look for a NUL termination in the given range,
+            // meaning, until we reach the end of the buffer or, the maximal reading count was reached.
+            while (currentCount < maxCount && currentPos < buffer.Length) {
+                // If the current byte is not a NUL termination, there is nothing to do,
+                // so just continue to looking through.
+                if (buffer[currentPos] != byte.MinValue) {
+                    ++currentPos;
+                    ++currentCount;
+                    continue;
+                }
+
+                // We found a NUL termination. Thus, we parse it to a string and stop here.
+                foundString = Encoding.ASCII.GetString(buffer, startIndex, currentCount);
+                return currentPos;
+            }
+
+            // We did not find a NUL termination in the given range,
+            // it's, thus, an invalid buffer. Throw an exception.
+            throw new NULTerminationNotFound();
+        }
+    }
+}

--- a/Shared/ByteUtils.cs
+++ b/Shared/ByteUtils.cs
@@ -4,15 +4,15 @@ using System.Text;
 namespace Shared {
     /// <inheritdoc />
     /// <summary>
-    /// An exception that occurs when looking for a <code>NUL termination</code>, but none is found.
+    /// An exception that occurs when looking for a <c>NUL</c> termination, but none is found.
     /// </summary>
     public class NULTerminationNotFound : SyntaxErrorException {}
 
     public class ByteUtils {
         /// <summary>
         /// Parse a string from a given bytes buffer, starting from a given point
-        /// until a <code>NUL termination</code> is found.
-        /// Throws an exception if the max byte count was reached without finding any NUL terminated string.
+        /// until a <c>NUL</c> termination is found.
+        /// Throws an exception if the max byte count was reached without finding any <c>NUL</c> terminated string.
         /// </summary>
         ///
         /// <param name="buffer">The buffer of bytes to read from.</param>
@@ -21,12 +21,12 @@ namespace Shared {
         /// <param name="foundString">The variable to store the parsed string into, if successfully parsed.</param>
         ///
         /// <returns>
-        /// The position of the <code>NUL termination</code> if any
+        /// The position of the <c>NUL</c> termination if any
         /// (<see cref="NULTerminationNotFound"/> is thrown otherwise).
         /// </returns>
         ///
         /// <exception cref="NULTerminationNotFound">
-        /// Thrown if it was unable to find a <code>NUL termination</code> in the given range.
+        /// Thrown if it was unable to find a <c>NUL</c> termination in the given range.
         /// </exception>
         public static ushort GetNulTerminatedString(
                 byte[] buffer, ushort startIndex, ushort maxCount, out string foundString) {

--- a/Shared/ChatMessage.cs
+++ b/Shared/ChatMessage.cs
@@ -39,7 +39,6 @@ namespace Shared {
         /// <summary>
         /// The minimal valid buffer size to be sent or be received.
         /// </summary>
-        /// <seealso cref="Shared.CommandType"/>
         public const int MINIMAL_BUFFER_SIZE =
                 2    // header
                 + 2  // nickname + NUL

--- a/Shared/ControlledEnvironment.cs
+++ b/Shared/ControlledEnvironment.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Shared {
     /// <summary>
@@ -43,8 +44,12 @@ namespace Shared {
         /// <inheritdoc />
         /// <summary>
         /// The real runtime exit function.
+        ///
+        /// This has to be excluded from test coverage, as it would exit tests,
+        /// making them uncompleted.
         /// </summary>
         /// <param name="errorCode"></param>
+        [ExcludeFromCodeCoverage]
         public override void Exit(int errorCode) {
             Environment.Exit(errorCode);
         }

--- a/Shared/IPUtils.cs
+++ b/Shared/IPUtils.cs
@@ -10,12 +10,12 @@ namespace Shared {
         /// <param name="inputEndpoint">The input string to parse.</param>
         /// <param name="parsedEndPoint">
         /// The result output.
-        /// Will be <code>null</code> if <see cref="inputEndpoint"/> is invalid.
+        /// Will be <c>null</c> if <see cref="inputEndpoint"/> is invalid.
         /// </param>
         ///
         /// <returns>
-        /// <code>False</code> is the string was containing invalid data,
-        /// <code>True</code> if the parsing was successful.
+        /// <c>False</c> is the string was containing invalid data,
+        /// <c>True</c> if the parsing was successful.
         /// </returns>
         public static bool TryParseEndpoint(string inputEndpoint, out IPEndPoint parsedEndPoint) {
             // Split the port from the input string, if it's provided.

--- a/Tests/TestClient/TestArgumentParsing.cs
+++ b/Tests/TestClient/TestArgumentParsing.cs
@@ -11,7 +11,7 @@ namespace Tests.TestClient {
         /// <summary>
         /// Test <see cref="ClientProgram.ParseArgs"/> against invalid argument count,
         /// which, are expected to trigger a call to
-        /// <see cref="ClientProgram.PrintUsage"/> with the error code: <code>1</code>.
+        /// <see cref="ClientProgram.PrintUsage"/> with the error code: <tt>1</tt>.
         /// </summary>
         /// <param name="args">The passed system arguments.</param>
         [TestCase(arg: new string[]{})]
@@ -35,8 +35,8 @@ namespace Tests.TestClient {
         }
 
         /// <summary>
-        /// Test <see cref="ClientProgram.ParseArgs"/> is handling <code>--help</code>.
-        /// <see cref="ClientProgram.PrintUsage"/> should thus be called with the error code: <code>0</code>.
+        /// Test <see cref="ClientProgram.ParseArgs"/> is handling <tt>--help</tt>.
+        /// <see cref="ClientProgram.PrintUsage"/> should thus be called with the error code: <tt>0</tt>.
         /// </summary>
         [TestCase]
         public void Test_ParseArgs_GetHelp() {
@@ -58,7 +58,7 @@ namespace Tests.TestClient {
         }
 
         /// <summary>
-        /// Test <see cref="ClientProgram.ParseArgs"/> is exiting the application with <code>1</code>
+        /// Test <see cref="ClientProgram.ParseArgs"/> is exiting the application with <tt>1</tt>
         /// if the provided data is invalid.
         /// </summary>
         [TestCase]

--- a/Tests/TestShared/TestByteUtils.cs
+++ b/Tests/TestShared/TestByteUtils.cs
@@ -1,0 +1,80 @@
+using System.Text;
+using NUnit.Framework;
+using Shared;
+
+namespace Tests.TestShared {
+    public class TestByteUtils {
+        /// <summary>
+        /// Test <see cref="ByteUtils.GetNulTerminatedString"/> against valid buffers to check
+        /// if it's correctly handling every case of mixed count vs start pos, including empty results.
+        ///
+        /// It also ensures that the pointer is correctly returned as being
+        /// at the position of the <code>NUL</code> termination.
+        /// </summary>
+        ///
+        /// <param name="startIndex">The index from which it will need to start looking from.</param>
+        /// <param name="maxCount">The maximum count of chars to looks at.</param>
+        /// <param name="inputString">The input string to convert to an array of bytes to extract from.</param>
+        /// <param name="expectedStringResult">The expected string that we should get from the function.</param>
+        [TestCase(0, 12, "Hello world\0", "Hello world")]
+        [TestCase(0, 12, "Hello worl\0d", "Hello worl")]
+        [TestCase(1, 12, "Hello worl\0d", "ello worl")]
+        [TestCase(1, 12, "H\0d", "")]
+        [TestCase(0, 12, "\0d", "")]
+        public void Test_GetNulTerminatedString_ValidData(
+                int startIndex, int maxCount,
+                string inputString, string expectedStringResult) {
+
+            // Convert the input string to an array of bytes
+            var inputBuffer = Encoding.ASCII.GetBytes(inputString);
+
+            // Get the expected end position, which is equal to the position of the first NUL
+            var expectedEndIndex = (ushort)inputString.IndexOf('\0');
+
+            // Test if the end index was the one expected (at `\0`)
+            Assert.AreEqual(
+                expectedEndIndex,
+                ByteUtils.GetNulTerminatedString(
+                    buffer: inputBuffer,
+                    startIndex: (ushort)startIndex,
+                    maxCount: (ushort)maxCount,
+                    foundString: out var foundString
+                )
+            );
+
+            // Test if the found string is was we expected to get (before `\0`)
+            Assert.AreEqual(foundString, expectedStringResult);
+        }
+
+        /// <summary>
+        /// Test <see cref="ByteUtils.GetNulTerminatedString"/> against invalid buffers to check
+        /// if it's correctly handling the cases of wrong data being received.
+        /// </summary>
+        ///
+        /// <param name="startIndex">The index from which it will need to start looking from.</param>
+        /// <param name="maxCount">The maximum count of chars to looks at.</param>
+        /// <param name="inputString">The input string to convert to an array of bytes to extract from.</param>
+        [TestCase(0, 11, "Hello world\0")]
+        [TestCase(0, 101, "Hello world :)")]
+        [TestCase(0, 11, "Hello world")]
+        [TestCase(0, 5, "Hello world")]
+        [TestCase(0, 10, "Hello worl\0d")]
+        [TestCase(1, 12, "\0")]
+        [TestCase(1, 12, "\0Hd")]
+        [TestCase(0, 1, "d\0")]
+        public void Test_GetNulTerminatedString_InvalidData(int startIndex, int maxCount, string inputString) {
+            // Convert the input string to an array of bytes
+            var inputBuffer = Encoding.ASCII.GetBytes(inputString);
+
+            // Test if the end index was the one expected (at `\0`)
+            Assert.Throws<NULTerminationNotFound>(
+                () => ByteUtils.GetNulTerminatedString(
+                        buffer: inputBuffer,
+                        startIndex: (ushort)startIndex,
+                        maxCount: (ushort)maxCount,
+                        foundString: out _
+                )
+            );
+        }
+    }
+}

--- a/Tests/TestShared/TestByteUtils.cs
+++ b/Tests/TestShared/TestByteUtils.cs
@@ -9,7 +9,7 @@ namespace Tests.TestShared {
         /// if it's correctly handling every case of mixed count vs start pos, including empty results.
         ///
         /// It also ensures that the pointer is correctly returned as being
-        /// at the position of the <code>NUL</code> termination.
+        /// at the position of the <c>NUL</c> termination.
         /// </summary>
         ///
         /// <param name="startIndex">The index from which it will need to start looking from.</param>

--- a/Tests/TestShared/TestChatMessage.cs
+++ b/Tests/TestShared/TestChatMessage.cs
@@ -8,9 +8,57 @@ namespace Tests.TestShared {
         /// does not raise any exception.
         /// </summary>
         /// <param name="bufferToDecode">The bytes to attempt to decode.</param>
-        [TestCase(arg: new byte[] {0xFF, 0xFF})]
+        [TestCase(arg: new byte[] {0xFF, 0xFE, 0x48, 0, 0x48, 0})]
         public void Test_ChatMessage_DeserializeInvalidCommandData(byte[] bufferToDecode) {
-            Assert.Pass(new ChatMessage(dataBuffer: bufferToDecode).ToString());
+            var result = new ChatMessage(dataBuffer: bufferToDecode).ToString();
+            Assert.AreEqual(result, "[254][255][1] H: H");
+        }
+
+        /// <summary>
+        /// Ensures <see cref="ChatMessage.GetBytes"/> correctly transforms given data
+        /// to bytes.
+        ///
+        /// Note: it's not its job to check the lengths.
+        /// </summary>
+        [TestCase]
+        public void Test_GetBytes_WithValidData() {
+            // Create a dummy message
+            var chatMessage = new ChatMessage(Command.GET, CommandType.RESPONSE, "Hi", "Data");
+
+            // Convert the message to bytes
+            var buffer = chatMessage.GetBytes();
+
+            // Check the buffer is what we expected
+            Assert.AreEqual(
+                buffer,
+                new byte[] {
+                    // header
+                    (byte)Command.GET,
+                    (byte)CommandType.RESPONSE,
+
+                    // nickname + NUL
+                    72, 105, byte.MinValue,
+
+                    // data + NUL
+                    68, 97, 116, 97, byte.MinValue
+            });
+
+            // Ensure the deserialization returns the exact same data
+            var newChatMessage = new ChatMessage(buffer);
+            Assert.AreEqual(chatMessage.Command, newChatMessage.Command);
+            Assert.AreEqual(chatMessage.CommandType, newChatMessage.CommandType);
+            Assert.AreEqual(chatMessage.Nickname, newChatMessage.Nickname);
+            Assert.AreEqual(chatMessage.Data, newChatMessage.Data);
+        }
+
+        /// <summary>
+        /// Test the <see cref="ChatMessage.ToString"/> method is returning what we expect.
+        /// </summary>
+        [TestCase]
+        public void Test_ToString_WithValidData() {
+            // Create a dummy message
+            var chatMessage = new ChatMessage(Command.GET, CommandType.RESPONSE, "Hi", "Data");
+            Assert.AreEqual(chatMessage.ToString(), "[RESPONSE][GET][4] Hi: Data");
         }
     }
 }

--- a/Tests/TestShared/TestChatMessage.cs
+++ b/Tests/TestShared/TestChatMessage.cs
@@ -1,0 +1,16 @@
+using NUnit.Framework;
+using Shared;
+
+namespace Tests.TestShared {
+    public class TestChatMessage {
+        /// <summary>
+        /// Ensure that passing invalid <see cref="Command"/> or <see cref="CommandType"/>
+        /// does not raise any exception.
+        /// </summary>
+        /// <param name="bufferToDecode">The bytes to attempt to decode.</param>
+        [TestCase(arg: new byte[] {0xFF, 0xFF})]
+        public void Test_ChatMessage_DeserializeInvalidCommandData(byte[] bufferToDecode) {
+            Assert.Pass(new ChatMessage(dataBuffer: bufferToDecode).ToString());
+        }
+    }
+}

--- a/Tests/TestShared/TestIPUtils.cs
+++ b/Tests/TestShared/TestIPUtils.cs
@@ -3,7 +3,7 @@ using Shared;
 
 namespace Tests.TestShared {
     /// <summary>
-    /// Test the <code>host[:port]</code> parsing utility of the internal IP utilities.
+    /// Test the <tt>host[:port]</tt> parsing utility of the internal IP utilities.
     /// </summary>
     public class TestIPUtils {
         /// <summary>


### PR DESCRIPTION
## References
Closes #2.

## Check list
2. [x] The serialization method `public byte[] GetBytes()` is implemented;
2. [x] The de-serialization construction method `public ChatMessage(byte[] buffer)` is implemented;
2. [x] The `ChatMessage` has a mandatory `nickname` field into the buffer;
2. [x] Invalid sizes are handled (fields, and the overall buffer).

