### PR TITLE
[v1.2] Added SUB and UNSUB commands, with their set of tests

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -7,11 +7,16 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RuntimeFrameworkVersion>2.1.4</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup>
     <Temp>$(SolutionDir)\packaging\</Temp>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETCore.App" Version="2.1.4" />
+  </ItemGroup>
 
   <ItemGroup>
     <BootStrapFiles Include="$(Temp)hostpolicy.dll;$(Temp)$(ProjectName).exe;$(Temp)hostfxr.dll;"/>

--- a/Client/ClientProgram.cs
+++ b/Client/ClientProgram.cs
@@ -98,7 +98,7 @@ namespace Client {
         /// Prompt the user to say yes, or no.
         /// </summary>
         /// <param name="promptMessage">The message to prompt to the user</param>
-        /// <returns></returns>
+        /// <returns><c>True</c> if the user said yes or nothing, <c>False</c> if they said no.</returns>
         public static bool PromptYesNo(string promptMessage) {
             while (true) {
                 // Prompt and read a key
@@ -139,7 +139,8 @@ namespace Client {
         /// <returns>The submitted command.</returns>
         public static Command PromptCommand() {
             while (true) {
-                var inputCommand = Prompt("Command (POST [0], GET [1], SUB [5] or UNSUB [7]): ", 10).ToUpper();
+                var inputCommand = Prompt(
+                    "Command (POST [0], GET [1], SUB [5] or UNSUB [7]): ", 10).ToUpper();
 
                 if (Enum.TryParse(inputCommand, out Command foundCommand)) {
                     return foundCommand;
@@ -238,12 +239,8 @@ namespace Client {
                     // Prompt the user, what message and command to send to the server
                     var chatMessage = PromptAllFields();
 
-                    // Convert this message to bytes
-                    var buffer = chatMessage.GetBytes();
-
-                    // Send the buffer to the server
-                    _clientSocket.SendTo(
-                        buffer, 0, buffer.Length, SocketFlags.None, _serverEndpoint);
+                    // Send the message to the server
+                    IPUtils.SendMessage(_clientSocket, chatMessage, _serverEndpoint);
 
                     // Log the message to stdout
                     Console.WriteLine(chatMessage);

--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -7,11 +7,16 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RuntimeFrameworkVersion>2.1.4</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup>
     <Temp>$(SolutionDir)\packaging\</Temp>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETCore.App" Version="2.1.4" />
+  </ItemGroup>
 
   <ItemGroup>
     <BootStrapFiles Include="$(Temp)hostpolicy.dll;$(Temp)$(ProjectName).exe;$(Temp)hostfxr.dll;"/>

--- a/Shared/IPUtils.cs
+++ b/Shared/IPUtils.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Sockets;
 
@@ -51,6 +52,7 @@ namespace Shared {
         /// <param name="remoteEndPoint">The sender's endpoint.</param>
         /// <returns>The received and parsed chat message.</returns>
         /// <exception cref="SyntaxErrorException">If the received byte buffer is invalid.</exception>
+        [ExcludeFromCodeCoverage]
         public static ChatMessage ReceiveMessage(Socket sourceSocket, out EndPoint remoteEndPoint) {
             // Create a IP address endpoint to store the client information into
             remoteEndPoint = new IPEndPoint(IPAddress.Any, 0);

--- a/Shared/IPUtils.cs
+++ b/Shared/IPUtils.cs
@@ -64,5 +64,27 @@ namespace Shared {
             // Decode the received buffer and return it
             return new ChatMessage(buffer);
         }
+
+        /// <summary>
+        /// Sends a given <see cref="ChatMessage"/> to a given <see cref="EndPoint"/>
+        /// using a given <see cref="Socket"/>.
+        /// </summary>
+        /// <param name="sourceSocket">The socket to use to send the message.</param>
+        /// <param name="chatMessage">The message to send.</param>
+        /// <param name="remoteEndPoint">The target endpoint.</param>
+        /// <returns>The number of bytes sent.</returns>
+        public static int SendMessage(
+                Socket sourceSocket, ChatMessage chatMessage, EndPoint remoteEndPoint) {
+            // Convert the message to a byte buffer
+            var bufferToSend = chatMessage.GetBytes();
+
+            // Send the message
+            return sourceSocket.SendTo(
+                buffer: bufferToSend,
+                offset: 0,
+                size: bufferToSend.Length,
+                socketFlags: SocketFlags.None,
+                remoteEP: remoteEndPoint);
+        }
     }
 }

--- a/Tests/TestServer/TestEvents.cs
+++ b/Tests/TestServer/TestEvents.cs
@@ -1,5 +1,9 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Sockets;
+using System.Text;
 using NUnit.Framework;
 using Server;
 using Shared;
@@ -23,12 +27,35 @@ namespace Tests.TestServer {
     /// </summary>
     public class TestEvents {
         private ChatMessage _chatMessage;
+        private StringWriter _textWriter;
+
+        /// <summary>
+        /// Generate a valid loopback endpoint,
+        /// but with a different memory address each time.
+        /// </summary>
+        /// <returns>The endpoint</returns>
+        private static IPEndPoint TestEndPoint() {
+            return new IPEndPoint(IPAddress.Loopback, ushort.MaxValue);
+        }
+
+        /// <summary>
+        /// Converts <see cref="_textWriter"/> to a <see cref="String"/>
+        /// and strip any whitespace.
+        /// </summary>
+        /// <returns>The stripped <see cref="_textWriter"/>.</returns>
+        private string ReadTextWritter() {
+            return this._textWriter.ToString().Trim();
+        }
 
         /// <summary>
         /// Store a dummy message.
         /// </summary>
         [SetUp]
         public void Setup() {
+            // Set-up a custom stdout to mock it
+            this._textWriter = new StringWriter();
+            Console.SetOut(this._textWriter);
+
             // The message to store
             this._chatMessage = new ChatMessage(
                 Command.POST, CommandType.RESPONSE, "Nick's name", "Hello world! :-)");
@@ -36,6 +63,9 @@ namespace Tests.TestServer {
             // Simulate the POST command, storing the message
             ServerProgram.handle_POST(
                 this._chatMessage, new IPEndPoint(IPAddress.Any, 0));
+
+            // Clear off the mocked text writer
+            this._textWriter.GetStringBuilder().Clear();
         }
 
         /// <summary>
@@ -44,6 +74,7 @@ namespace Tests.TestServer {
         [TearDown]
         public void TearDown() {
             ServerProgram.STORED_CHAT_MESSAGES.Clear();
+            ServerProgram.SUBSCRIBERS.Clear();
         }
 
         /// <summary>
@@ -64,11 +95,85 @@ namespace Tests.TestServer {
         public void Test_handle_GET() {
             // Initialize the test data and check the integrity
             ServerProgram.ServerSocket = new MockedSocket();
-            var clientEndPoint = new IPEndPoint(IPAddress.Loopback, ushort.MaxValue);
             Assert.AreEqual(ServerProgram.STORED_CHAT_MESSAGES.Count, 1);
 
             // Simulate the GET command, get the message
-            ServerProgram.handle_GET(null, clientEndPoint);
+            ServerProgram.handle_GET(null, TestEndPoint());
+        }
+
+        /// <summary>
+        /// Ensure the <see cref="ServerProgram.handle_SUB"/>
+        /// is correctly registering users, and the endpoints are kept unique
+        /// even if the objects are not of the same address.
+        /// </summary>
+        [TestCase]
+        public void Test_handle_SUB() {
+            // Ensure the subscribers list is empty
+            // and no data was written to the mocked console
+            Assert.AreEqual(ServerProgram.SUBSCRIBERS.Count, 0);
+            Assert.IsEmpty(this._textWriter.ToString());
+
+            // Simulate the SUB command
+            ServerProgram.handle_SUB(null, TestEndPoint());
+
+            // Ensure the subscription alert was written to the console
+            Assert.That(this.ReadTextWritter(), Does.EndWith(" just subscribed!"));
+            this._textWriter.GetStringBuilder().Clear();
+
+            // Ensure it fails to subscribe twice the same endpoint data
+            ServerProgram.handle_SUB(null, TestEndPoint());
+            Assert.IsEmpty(this._textWriter.ToString());
+
+            // Check if we are now subscribed
+            Assert.AreEqual(ServerProgram.SUBSCRIBERS.Count, 1);
+            CollectionAssert.AreEqual(
+                ServerProgram.SUBSCRIBERS, new HashSet<EndPoint> {TestEndPoint()});
+        }
+
+        /// <summary>
+        /// Ensure the <see cref="ServerProgram.handle_UNSUB"/>
+        /// is correctly unregistering users.
+        /// </summary>
+        [TestCase]
+        public void Test_handle_UNSUB() {
+            // Ensure the subscribers list is empty
+            // and no data was written to the mocked console
+            Assert.AreEqual(ServerProgram.SUBSCRIBERS.Count, 0);
+            Assert.AreEqual(ServerProgram.SUBSCRIBERS.Count, 0);
+            Assert.IsEmpty(this._textWriter.ToString());
+
+            // Simulate the SUB command to add a dummy subscriber
+            ServerProgram.handle_SUB(null, TestEndPoint());
+            Assert.AreEqual(ServerProgram.SUBSCRIBERS.Count, 1);
+
+            // Ensure the alert was written to the console
+            Assert.That(this.ReadTextWritter(), Does.EndWith(" just subscribed!"));
+
+            // Try to unsubscribe
+            ServerProgram.handle_UNSUB(null, TestEndPoint());
+            Assert.AreEqual(ServerProgram.SUBSCRIBERS.Count, 0);
+
+            // Ensure the alert was written to the console
+            Assert.That(this.ReadTextWritter(), Does.EndWith(" just unsubscribed!"));
+        }
+
+        /// <summary>
+        /// Ensure the <see cref="ServerProgram.handle_UNSUB"/>
+        /// does not crash when requested to unsubscribe a non subscriber.
+        /// </summary>
+        [TestCase]
+        public void Test_handle_UNSUB_withoutBeingSubscribed() {
+            // Ensure the subscribers list is empty
+            // and no data was written to the mocked console
+            Assert.AreEqual(ServerProgram.SUBSCRIBERS.Count, 0);
+            Assert.IsEmpty(this._textWriter.ToString());
+
+            // Try to unsubscribe a non subscribed endpoint
+            ServerProgram.handle_UNSUB(null, TestEndPoint());
+
+            // Ensure no alert was written to the console,
+            // meaning nothing was done, as expected
+            Assert.IsEmpty(this._textWriter.ToString());
         }
     }
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="nunit" Version="3.10.1" />
   </ItemGroup>
 


### PR DESCRIPTION
1. [x] `SUB` is adding requesters endpoint into the server;
1. [x] `SUB` does nothing if the request's endpoint is **already** subbed;
1. [x] `UNSUB` is removing the requester's endpoint;
1. [x] `UNSUB` does nothing if the request's endpoint is **not yet** subbed;
1. [x] `POST` command is sending the saved message to the subscribers;
1. [x] The client now waits for messages (<1ms) after any command, and from the start until the user requests to stop looking for messages;
1. [x] The changes are tested, and, covered;
1. [x] The changes are fully commented.