### PR TITLE
[v1.3] Fixes and moved the message receiver into a thread

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -19,22 +19,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <BootStrapFiles Include="$(Temp)hostpolicy.dll;$(Temp)$(ProjectName).exe;$(Temp)hostfxr.dll;"/>
+    <BootStrapFiles Include="$(Temp)hostpolicy.dll;$(Temp)$(ProjectName).exe;$(Temp)hostfxr.dll;" />
   </ItemGroup>
 
-  <Target Name="GenerateNetcoreExe"
-          AfterTargets="Build"
-          Condition="'$(IsNestedBuild)' != 'true'">
+  <Target Name="GenerateNetcoreExe" AfterTargets="Build" Condition="'$(IsNestedBuild)' != 'true'">
     <RemoveDir Directories="$(Temp)" />
-    <Exec
-      ConsoleToMSBuild="true"
-      Command="dotnet build $(ProjectPath) -r win-x64 /p:CopyLocalLockFileAssemblies=false;IsNestedBuild=true --output $(Temp)" >
+    <Exec ConsoleToMSBuild="true" Command="dotnet build $(ProjectPath) -r win-x64 /p:CopyLocalLockFileAssemblies=false;IsNestedBuild=true --output $(Temp)">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
-    <Copy
-      SourceFiles="@(BootStrapFiles)"
-      DestinationFolder="$(OutputPath)"
-    />
+    <Copy SourceFiles="@(BootStrapFiles)" DestinationFolder="$(OutputPath)" />
 
   </Target>
 </Project>

--- a/Client/ClientProgram.cs
+++ b/Client/ClientProgram.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Net;
-using System.Net.Sockets;
 using Shared;
 using CommandType = Shared.CommandType;
 
@@ -17,26 +15,51 @@ namespace Client {
         public const string HELP_ARGUMENT = "--help";
 
         /// <summary>
-        /// The server endpoint to which we want to send data.
-        /// This initialize a the default server config, it may get overriden by the user in
-        /// <see cref="ParseArgs"/>.
-        ///
-        /// For more information, see: <see cref="PrintUsage"/>.
+        /// The user's custom nickname (mandatory).
         /// </summary>
-        private static IPEndPoint _serverEndpoint = new IPEndPoint(
-            DefaultConfig.DEFAULT_SERVER_HOST, DefaultConfig.DEFAULT_SERVER_PORT);
-
-        /// <summary>
-        /// The client's socket that it's using to communicate with the server.
-        /// Storing this value as a global will allow us to retrieve data from
-        /// the server later on.
-        /// </summary>
-        private static Socket _clientSocket;
+        private static string _nickname;
 
         /// <summary>
         /// The user's custom nickname (mandatory).
         /// </summary>
-        private static string _nickname;
+        private static DisposableClient _disposableClient;
+
+        /// <summary>
+        /// Register the events that gets asynchronously triggered.
+        ///
+        /// <list type="bullet">
+        ///     <item>
+        ///         <term><c>CancelKeyPress</c></term>
+        ///         <description>
+        ///         Whenever the user hits <tt>CTRL+C</tt>, dispatching a <c>Dispose</c>
+        ///         event to the <see cref="_disposableClient"/>, to clean up everything (thread, and sockets).
+        ///         Then, when everything is clean, exits with <tt>1</tt>.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <term><c>MessageReceivedEvent</c></term>
+        ///         <description>
+        ///         Whenever a message was received from the targeted chat (see <see cref="ParseArgs"/>)
+        ///         server, it prints it to <tt>stdout</tt>.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// </summary>
+        private static void RegisterEvents() {
+            // .NET does not dispatch the termination event to disposables and finally blocks,
+            // thus, we manually tell .NET not to handle the termination and just dispatch it
+            // to the disposable that will handle all the cleaning, and then exit.
+            Console.CancelKeyPress += (sender, eventArgs) => {
+                _disposableClient?.Dispose();
+                eventArgs.Cancel = true;
+                Environment.Exit(1);
+            };
+
+            // Log each received message to stdout
+            _disposableClient.MessageReceivedEvent += (receivedMessage, remoteEndpoint) => {
+                Console.WriteLine(Environment.NewLine + receivedMessage);
+            };
+        }
 
         /// <summary>
         /// Prints the usage of this program.
@@ -58,12 +81,36 @@ namespace Client {
         }
 
         /// <summary>
+        /// Prompt the user to input a message, for ever.
+        /// Each message submitted by the user is sent to a given server (more info: <see cref="Main"/>),
+        /// and logged into <tt>stdout</tt>.
+        /// </summary>
+        private static void PromptForMessageForEver() {
+            // While the client is active, wait for the user's input
+            while (_disposableClient.IsActive) {
+                // Prompt the user, what message and command to send to the server
+                var chatMessage = PromptAllFields();
+
+                // Send the message to the server
+                _disposableClient.SendMessage(chatMessage);
+
+                // Log the message to stdout
+                Console.WriteLine(chatMessage);
+            }
+        }
+
+        /// <summary>
         /// Parse the arguments that the application received.
-        /// It's expecting a non empty collection of string.
         /// </summary>
         /// <param name="args"></param>
-        public static void ParseArgs(IReadOnlyList<string> args) {
-            if (args.Count != 1) {
+        /// <param name="serverEndpoint">The parsed server's <see cref="IPEndPoint"/></param>
+        public static void ParseArgs(IReadOnlyList<string> args, out IPEndPoint serverEndpoint) {
+            serverEndpoint = null;
+
+            if (args.Count == 0) {
+                serverEndpoint = DefaultConfig.GetDefaultEndPoint();
+            }
+            else if (args.Count > 1) {
                 // An invalid argument count was passed, it's an error.
                 PrintUsage(isAnError: true);
             }
@@ -71,59 +118,28 @@ namespace Client {
                 // The user requested help, show it.
                 PrintUsage(isAnError: false);
             }
-            else if (!IPUtils.TryParseEndpoint(args[0], out _serverEndpoint)) {
+            else if (!IPUtils.TryParseEndpoint(args[0], out serverEndpoint)) {
                 // The user passed `host[:port]` and it was unsuccessfully parsed.
                 PrintUsage(isAnError: true);
             }
         }
 
         /// <summary>
-        ///
+        /// Prompt a given message and ensure it's not longer than the maximal length accepted.
         /// </summary>
-        /// <param name="promptMessage"></param>
-        /// <param name="maximalLength"></param>
+        /// <param name="promptMessage">The message to prompt.</param>
+        /// <param name="maximalLength">The maximal length.</param>
         /// <returns></returns>
         public static string Prompt(string promptMessage, int maximalLength) {
             var readString = string.Empty;
 
+            // Prompt the user until the message is no longer empty, or non longer too long
             while (readString?.Length < 1 || readString?.Length > maximalLength) {
                 Console.Write(promptMessage);
                 readString = Console.ReadLine()?.Trim();
             }
 
             return readString;
-        }
-
-        /// <summary>
-        /// Prompt the user to say yes, or no.
-        /// </summary>
-        /// <param name="promptMessage">The message to prompt to the user</param>
-        /// <returns><c>True</c> if the user said yes or nothing, <c>False</c> if they said no.</returns>
-        public static bool PromptYesNo(string promptMessage) {
-            while (true) {
-                // Prompt and read a key
-                Console.Write(promptMessage);
-                var readKey = Console.ReadKey();
-
-                // Put the cursor on the beginning of a new line
-                Console.WriteLine();
-
-                // Parse the key:
-                //   - Y/Return: return true,
-                //   - N: return false,
-                //   - others: UNK, ask again.
-                switch (readKey.Key) {
-                    case ConsoleKey.Enter:
-                    case ConsoleKey.Y:
-                        return true;
-
-                    case ConsoleKey.N:
-                        return false;
-
-                    default:
-                        continue;
-                }
-            }
         }
 
         /// <summary>
@@ -139,9 +155,14 @@ namespace Client {
         /// <returns>The submitted command.</returns>
         public static Command PromptCommand() {
             while (true) {
-                var inputCommand = Prompt(
-                    "Command (POST [0], GET [1], SUB [5] or UNSUB [7]): ", 10).ToUpper();
+                // Prompt for a single key
+                Console.Write("Command (POST = 0, GET = 1, SUB = 5, and UNSUB = 7): ");
+                var inputCommand = Console.ReadKey().KeyChar.ToString();
 
+                // Return at the beginning of a new line
+                Console.WriteLine();
+
+                // Attempt to parse it
                 if (Enum.TryParse(inputCommand, out Command foundCommand)) {
                     return foundCommand;
                 }
@@ -166,89 +187,26 @@ namespace Client {
         }
 
         /// <summary>
-        /// Attempt to receive messages from the server,
-        /// will throw <see cref="SocketError"/> if it's unable to connect to the server.
-        /// </summary>
-        public static void ReceiveMessages() {
-            // Check if data is available to be received.
-            // Stop looking for messages after 1ms.
-            while (_clientSocket.Poll(10000, SelectMode.SelectRead)) {
-                EndPoint remoteEndPoint = null;
-                try {
-                    // Wait for a message, retrieve it and decode it
-                    var receivedMessage = IPUtils.ReceiveMessage(_clientSocket, out remoteEndPoint);
-
-                    // Handle the received message
-                    Console.WriteLine(receivedMessage);
-                }
-                catch (SyntaxErrorException) {
-                    Console.WriteLine(
-                        "Warning: received an invalid message from {0}", remoteEndPoint);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Check for incoming messages until the user says to stop or continue.
-        /// </summary>
-        public static void ControlledMessagesChecking() {
-            do {
-                try {
-                    // Wait for a response from the server
-                    Console.WriteLine("*** Looking for incoming messages (~1ms)...");
-                    ReceiveMessages();
-                }
-                catch (SocketException) {
-                    // Catch the error if we were unable to connect to the server,
-                    // and let the user know there was a connectivity issue.
-                    Console.WriteLine(
-                        "Failed to listen for messages onto {0}", _serverEndpoint);
-                }
-            }
-            // Ask the user if they want to continue looking for new messages or not.
-            // A blank message from the user will mean to continue looking.
-            while (
-                PromptYesNo("Continue looking for incoming messages? Yes/ No. [default: Yes] "));
-        }
-
-        /// <summary>
-        /// The entry point of the UDP chat client.
+        /// The entry point of the UDP chat client. It starts a connection to a given server
+        /// (see <see cref="ParseArgs"/>), and then, whenever everything is safe (see <see cref="RegisterEvents"/>),
+        /// it waits for the user to send messages.
         /// </summary>
         /// <param name="args"></param>
         private static void Main(string[] args) {
-            // If there are any passed argument values, parse them.
-            if (args.Length > 0) {
-                ParseArgs(args);
-            }
+            // Parse passed argument values
+            ParseArgs(args, out var serverEndpoint);
 
             // Prompt for a nickname
             _nickname = Prompt(
-                "Nickname: ", ChatMessage.MAX_NICKNAME_SIZE - 1);  // The maximal nickname length, excluding NUL
+                "Nickname: ", ChatMessage.MAX_NICKNAME_SIZE - 1); // The maximal nickname length, excluding NUL
 
-            // Log the server endpoint that we are going to use,
-            // and prepare a UDP socket to use to send message to the server.
-            Console.WriteLine("Using {0}", _serverEndpoint);
-            _clientSocket =
-                new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            using (_disposableClient = new DisposableClient(serverEndpoint)) {
+                // Register every async events to the client before
+                // entering the blocking mode
+                RegisterEvents();
 
-            try {
-                while (true) {
-                    // Check for messages and prompt the user what to do (continue or stop)
-                    ControlledMessagesChecking();
-
-                    // Prompt the user, what message and command to send to the server
-                    var chatMessage = PromptAllFields();
-
-                    // Send the message to the server
-                    IPUtils.SendMessage(_clientSocket, chatMessage, _serverEndpoint);
-
-                    // Log the message to stdout
-                    Console.WriteLine(chatMessage);
-                }
-            }
-            finally {
-                // Finally, close the socket
-                _clientSocket.Close();
+                // Prompt the user to send a message, forever
+                PromptForMessageForEver();
             }
         }
     }

--- a/Client/DisposableClient.cs
+++ b/Client/DisposableClient.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Data;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using Shared;
+
+namespace Client {
+    /// <inheritdoc />
+    /// <summary>
+    /// A disposable chat client, that auto
+    /// </summary>
+    public class DisposableClient : IDisposable {
+        /// <summary>
+        /// The client's forever message listening task.
+        /// </summary>
+        private Thread _messageListeningThread;
+
+        /// <summary>
+        /// The polling time (in <tt>us</tt>) on the <see cref="ClientSocket"/>
+        /// </summary>
+        private const int POLLING_TIME_MICROSECONDS = 20000;
+
+        /// <summary>
+        /// The server endpoint to which we want to send data.
+        /// </summary>
+        public readonly IPEndPoint ServerEndpoint;
+
+        /// <summary>
+        /// The invoked event whenever a message is received from the server.
+        /// </summary>
+        ///
+        /// <param name="chatMessage">
+        /// The received message.
+        /// </param>
+        /// <param name="remoteEndpoint">
+        /// The remote endpoint from where the message came (the server, supposedly).
+        /// </param>
+        public delegate void OnMessageReceived(ChatMessage chatMessage, EndPoint remoteEndpoint);
+
+        /// <summary>
+        /// The event that gets invoked whenever a message is received
+        /// from the given server.
+        /// </summary>
+        public event OnMessageReceived MessageReceivedEvent;
+
+        /// <summary>
+        /// The client's state, whether it should be stopping or keep on running.
+        /// </summary>
+        public bool IsActive { get; private set; } = true;
+
+        /// <summary>
+        /// The client's socket that it's using to communicate with the server.
+        /// Storing this value as a global will allow us to retrieve data from
+        /// the server later on.
+        /// </summary>
+        public Socket ClientSocket;
+
+        /// <summary>
+        /// Initialize and start a disposable client that will listen on a given <see cref="serverEndpoint"/>.
+        /// Then will get clean up everything through the <see cref="Dispose"/> method.
+        /// </summary>
+        /// <param name="serverEndpoint">The server's endpoint to be listened on for new messages.</param>
+        public DisposableClient(IPEndPoint serverEndpoint) {
+            this.ServerEndpoint = serverEndpoint;
+            this.Start();
+        }
+
+        /// <summary>
+        /// Start a disposable client listening on a given server endpoint (<see cref="ServerEndpoint"/>)
+        /// for new messages in a separated thread.
+        /// And send any provided messages using <see cref="SendMessage"/> to the server.
+        /// </summary>
+        private void Start() {
+            this.ClientSocket =
+                new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+
+            // Linking the socket to the communication point
+            this.ClientSocket.Bind(new IPEndPoint(IPAddress.Any, 0));
+
+            // Check for messages and prompt the user what to do (continue or stop)
+            this._messageListeningThread = new Thread(ReceiveMessagesForEver);
+            this._messageListeningThread.Start();
+        }
+
+        /// <summary>
+        /// Check for messages to be received,
+        /// keep the method blocked for <see cref="POLLING_TIME_MICROSECONDS"/> microseconds.
+        ///
+        /// If a message was received, invoke the <see cref="MessageReceivedEvent"/>.
+        /// </summary>
+        private void WaitForMessage() {
+            // Check if data is available to be received.
+            // Stop looking for messages after a few given micro-seconds.
+            while (this.ClientSocket.Poll(POLLING_TIME_MICROSECONDS, SelectMode.SelectRead)) {
+                EndPoint remoteEndPoint = null;
+                try {
+                    // Wait for a message, retrieve it and decode it
+                    var receivedMessage = IPUtils.ReceiveMessage(this.ClientSocket, out remoteEndPoint);
+
+                    // Propagate the received message
+                    this.MessageReceivedEvent?.Invoke(receivedMessage, remoteEndPoint);
+                }
+                catch (SyntaxErrorException) {
+                    Console.WriteLine(
+                        "Warning: received an invalid message from {0}", remoteEndPoint);
+                }
+                catch (SocketException) {
+                    // Wait a little before retrying (in milliseconds)
+                    Thread.Sleep(100);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Attempt to receive messages from the server,
+        /// will throw <see cref="SocketError"/> if it's unable to connect to the server.
+        /// </summary>
+        private void ReceiveMessagesForEver() {
+            // While this task is needed, let it look for messages
+            while (this.IsActive) {
+                this.WaitForMessage();
+            }
+
+            // Log that the task just finished
+            Console.Error.WriteLine("Stopped listening for new messages.");
+        }
+
+        /// <summary>
+        /// Send a message to the server using the <see cref="ClientSocket"/>.
+        /// </summary>
+        /// <param name="chatMessage"></param>
+        public void SendMessage(ChatMessage chatMessage) {
+            IPUtils.SendMessage(this.ClientSocket, chatMessage, this.ServerEndpoint);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// Flag the <see cref="IDisposable"/> implementation
+        /// as to stop listening on the server for new messages
+        /// and wait for the sub thread(s) to handle the exit flag.
+        /// Then, close the <see cref="ClientSocket"/>.
+        /// </summary>
+        public void Dispose() {
+            // Flag the application to stop itself
+            this.IsActive = false;
+            Console.Error.WriteLine();
+
+            // Wait for the thread to stop listening for new messages
+            if (this._messageListeningThread.IsAlive) {
+                Console.Error.WriteLine("Waiting for the client to stop listening...");
+                this._messageListeningThread.Join();
+            }
+
+            // Close the socket
+            Console.Error.WriteLine("Closing the connection...");
+            this.ClientSocket.Close();
+        }
+    }
+}

--- a/Server/ServerProgram.cs
+++ b/Server/ServerProgram.cs
@@ -178,15 +178,21 @@ namespace Server {
         /// Listens for messages and handle them.
         /// </summary>
         private static void ProcessMessages() {
+            EndPoint clientEndPoint = null;
             try {
                 // Wait for a message, retrieve it and decode it
-                var receivedMessage = IPUtils.ReceiveMessage(_serverSocket, out var clientEndPoint);
+                var receivedMessage = IPUtils.ReceiveMessage(_serverSocket, out clientEndPoint);
 
                 // Handle the received message
                 HandleMessage(receivedMessage, clientEndPoint);
             }
             catch (SyntaxErrorException) {
                 LogInfo("received an invalid message.");
+            }
+            catch (SocketException exc) {
+                LogInfo(
+                    "A connection with {0} was not properly ended. Reason: {1}",
+                    clientEndPoint, exc.Message);
             }
         }
 

--- a/Shared/DefaultConfig.cs
+++ b/Shared/DefaultConfig.cs
@@ -1,8 +1,19 @@
 using System.Net;
 
 namespace Shared {
+    /// <summary>
+    /// The default client and server shared config.
+    /// </summary>
     public static class DefaultConfig {
         public const short DEFAULT_SERVER_PORT = 6000;
         public static readonly IPAddress DEFAULT_SERVER_HOST = IPAddress.Loopback;
+
+        /// <summary>
+        /// Returns the default server's endpoint config.
+        /// </summary>
+        /// <returns>The default server's endpoint.</returns>
+        public static IPEndPoint GetDefaultEndPoint() {
+            return new IPEndPoint(DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT);
+        }
     }
 }


### PR DESCRIPTION
- Fix the server's handling of non properly closed client connections,
  closes #6;
- Doing a CTRL+Z on the message input, no longer crashes the client;
- Requesting the client to kill itself, now properly closes
  the client socket. C# is not climbing back the stack or cleaning
  disposables when getting killed. This case is now handled;
- No longer a allow a full command name input, to allow the user
  to quickly send a wanted command, in only one key,
  not two (e.g.: 0 + Return);
- The default endpoint configuration is now a method,
  which is the proper, and clean way to do;
- The argument parsing, now handles (again) empty arguments and, thus,
  Main() does not have to check anything anymore. Making the code
  cleaner;
- No longer logging whenever an issue occurred while receiving a message
  from the client socket (e.g. timeout). This could,
  and may will be replaced later by a server status
  feedback on the client;
- Simplified the client's SendMessage, making it cleaner;
- The whole client can now be thread safe and cleanly independent,
  as the client is now a object that can get destroyed without exiting
  the application, or depending on the application.