### PR TITLE
[v1.4] Add rooms support to the server and client

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -1,5 +1,23 @@
 # Change logs
 
+## v1.4
+- Implemented the below commands:
+
+  | Command      | Description  |
+  |--------------|--------------|
+  | `QUIT      ` | Closes the client (client command). |
+  | `HELP      ` | Retrieve the list of available commands (client command). |
+  | `EXIT      ` | Closes and removes the current server room's connection. |
+  | `CREATEROOM` | Creates a new room in a given server, which opens a new port. |
+  | `LISTROOMS ` | Lists the available rooms of the currently connected server (see the `CONNECT` command).             |
+  | `CONNECT   ` | Connect to a given `IP[:port]` combination. |
+  
+- Refactored the static server for an instantiable server class, 
+  allowing more flexibility;
+- Fixed a bug where if the client's listening `IPEndpoint` 
+  was set to a non-routable IP, it would crash 
+  (fixes [#9](https://github.com/NyanKiyoshi/iutrs-topiscuss/issues/9)).
+
 ## v1.3
 - Fix the server's handling of non properly closed client connections,
   closes [#6](https://github.com/NyanKiyoshi/iutrs-topiscuss/issues/6);

--- a/Client/ClientProgram.cs
+++ b/Client/ClientProgram.cs
@@ -91,6 +91,10 @@ namespace Client {
                 // Prompt the user, what message and command to send to the server
                 var chatMessage = PromptAllFields();
 
+                if (chatMessage.Command == Command.QUIT) {
+                    break;
+                }
+
                 // Send the message to the server
                 _disposableClient.SendMessage(chatMessage);
 

--- a/Client/ClientProgram.cs
+++ b/Client/ClientProgram.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using Shared;
 using CommandType = Shared.CommandType;
 
@@ -95,11 +97,18 @@ namespace Client {
                     break;
                 }
 
-                // Send the message to the server
-                _disposableClient.SendMessage(chatMessage);
+                try {
+                    // Log the message to stdout
+                    Console.WriteLine(chatMessage);
 
-                // Log the message to stdout
-                Console.WriteLine(chatMessage);
+                    // Send the message to the server
+                    _disposableClient.SendMessage(chatMessage);
+                }
+                catch (SocketException exc) {
+                    Console.Error.WriteLine(
+                        "Failed to send the message, please check the provided endpoint. " +
+                        "Received response: {0}", exc.Message);
+                }
             }
         }
 
@@ -133,6 +142,7 @@ namespace Client {
         /// </summary>
         /// <param name="promptMessage">The message to prompt.</param>
         /// <param name="maximalLength">The maximal length.</param>
+        /// <param name="arg">The format arguments.</param>
         /// <returns></returns>
         public static string Prompt(string promptMessage, int maximalLength) {
             var readString = string.Empty;
@@ -159,14 +169,8 @@ namespace Client {
         /// <returns>The submitted command.</returns>
         public static Command PromptCommand() {
             while (true) {
-                // Prompt for a single key
-                Console.Write("Command (POST = 0, GET = 1, SUB = 5, and UNSUB = 7): ");
-                var inputCommand = Console.ReadKey().KeyChar.ToString();
+                var inputCommand = Prompt("Command ('HELP' for more info): ", 10).ToUpper();
 
-                // Return at the beginning of a new line
-                Console.WriteLine();
-
-                // Attempt to parse it
                 if (Enum.TryParse(inputCommand, out Command foundCommand)) {
                     return foundCommand;
                 }

--- a/Client/DisposableClient.cs
+++ b/Client/DisposableClient.cs
@@ -79,7 +79,7 @@ namespace Client {
             this.ClientSocket.Bind(new IPEndPoint(IPAddress.Any, 0));
 
             // Check for messages and prompt the user what to do (continue or stop)
-            this._messageListeningThread = new Thread(ReceiveMessagesForEver);
+            this._messageListeningThread = new Thread(this.ReceiveMessagesForEver);
             this._messageListeningThread.Start();
         }
 

--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -19,22 +19,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <BootStrapFiles Include="$(Temp)hostpolicy.dll;$(Temp)$(ProjectName).exe;$(Temp)hostfxr.dll;"/>
+    <BootStrapFiles Include="$(Temp)hostpolicy.dll;$(Temp)$(ProjectName).exe;$(Temp)hostfxr.dll;" />
   </ItemGroup>
 
-  <Target Name="GenerateNetcoreExe"
-          AfterTargets="Build"
-          Condition="'$(IsNestedBuild)' != 'true'">
+  <Target Name="GenerateNetcoreExe" AfterTargets="Build" Condition="'$(IsNestedBuild)' != 'true'">
     <RemoveDir Directories="$(Temp)" />
-    <Exec
-      ConsoleToMSBuild="true"
-      Command="dotnet build $(ProjectPath) -r win-x64 /p:CopyLocalLockFileAssemblies=false;IsNestedBuild=true --output $(Temp)" >
+    <Exec ConsoleToMSBuild="true" Command="dotnet build $(ProjectPath) -r win-x64 /p:CopyLocalLockFileAssemblies=false;IsNestedBuild=true --output $(Temp)">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
-    <Copy
-      SourceFiles="@(BootStrapFiles)"
-      DestinationFolder="$(OutputPath)"
-    />
+    <Copy SourceFiles="@(BootStrapFiles)" DestinationFolder="$(OutputPath)" />
 
   </Target>
 </Project>

--- a/Server/ServerManager.cs
+++ b/Server/ServerManager.cs
@@ -1,0 +1,14 @@
+using Shared;
+
+namespace Server {
+    public static class ServerManager {
+        /// <summary>
+        /// Entry point for the UDP server(s), it opens a socket
+        /// and handles every incoming messages.
+        /// </summary>
+        private static void Main() {
+            var baseServerRoom = new ServerRoom();
+            baseServerRoom.Listen(DefaultConfig.DEFAULT_SERVER_PORT);
+        }
+    }
+}

--- a/Server/ServerManager.cs
+++ b/Server/ServerManager.cs
@@ -7,7 +7,7 @@ namespace Server {
         /// and handles every incoming messages.
         /// </summary>
         private static void Main() {
-            var baseServerRoom = new ServerRoom();
+            var baseServerRoom = new ServerRoom("Main");
             baseServerRoom.Listen(DefaultConfig.DEFAULT_SERVER_PORT);
         }
     }

--- a/Server/ServerManager.cs
+++ b/Server/ServerManager.cs
@@ -7,7 +7,7 @@ namespace Server {
         /// and handles every incoming messages.
         /// </summary>
         private static void Main() {
-            var baseServerRoom = new ServerRoom("Main");
+            var baseServerRoom = new ServerRoom();
             baseServerRoom.Listen(DefaultConfig.DEFAULT_SERVER_PORT);
         }
     }

--- a/Server/ServerRoom.cs
+++ b/Server/ServerRoom.cs
@@ -31,7 +31,8 @@ namespace Server {
                 {Command.GET, handle_GET},
                 {Command.POST, handle_POST},
                 {Command.SUB, handle_SUB},
-                {Command.UNSUB, handle_UNSUB}
+                {Command.UNSUB, handle_UNSUB},
+                {Command.STOP, handle_STOP}
             };
 
         /// <summary>
@@ -155,6 +156,15 @@ namespace Server {
         }
 
         /// <summary>
+        /// Handle the a <see cref="Command.STOP"/> request, shutdown the server.
+        /// </summary>
+        /// <param name="receivedMessage">The message received.</param>
+        /// <param name="clientEndPoint">The remote sender's endpoint.</param>
+        public static void handle_STOP(ChatMessage receivedMessage, EndPoint clientEndPoint) {
+            _serverSocket.Close();
+        }
+
+        /// <summary>
         /// The server socket from which we will bind ourselves and listen for incoming messages.
         /// </summary>
         private static Socket _serverSocket;
@@ -187,7 +197,7 @@ namespace Server {
                 HandleMessage(receivedMessage, clientEndPoint);
             }
             catch (SyntaxErrorException) {
-                LogInfo("received an invalid message.");
+                LogInfo("Received an invalid message.");
             }
             catch (SocketException exc) {
                 LogInfo(
@@ -216,6 +226,9 @@ namespace Server {
             }
             catch (SocketException exc) {
                 Console.WriteLine(exc.Message);
+            }
+            catch (ObjectDisposedException) {
+                Console.WriteLine("Server connection was closed...");
             }
             finally {
                 // Finally, close the server socking that we were listening on

--- a/Shared/ChatMessage.cs
+++ b/Shared/ChatMessage.cs
@@ -3,7 +3,7 @@ using System.Data;
 using System.Text;
 
 namespace Shared {
-    public enum Command {POST, GET, HELP, QUIT, STOP, SUB, SUB2, UNSUB}
+    public enum Command {POST, GET, HELP, QUIT, STOP, SUB, SUB2, UNSUB, CREATEROOM, LISTROOMS}
     public enum CommandType {REQUEST, RESPONSE}
 
     /// <inheritdoc />

--- a/Shared/ChatMessage.cs
+++ b/Shared/ChatMessage.cs
@@ -3,7 +3,7 @@ using System.Data;
 using System.Text;
 
 namespace Shared {
-    public enum Command {POST, GET, HELP, QUIT, STOP, SUB, SUB2, UNSUB, CREATEROOM, LISTROOMS}
+    public enum Command {POST, GET, HELP, QUIT, STOP, SUB, SUB2, UNSUB, CREATEROOM, LISTROOMS, CONNECT}
     public enum CommandType {REQUEST, RESPONSE}
 
     /// <inheritdoc />

--- a/Shared/DefaultConfig.cs
+++ b/Shared/DefaultConfig.cs
@@ -5,7 +5,7 @@ namespace Shared {
     /// The default client and server shared config.
     /// </summary>
     public static class DefaultConfig {
-        public const short DEFAULT_SERVER_PORT = 6000;
+        public const ushort DEFAULT_SERVER_PORT = 6000;
         public static readonly IPAddress DEFAULT_SERVER_HOST = IPAddress.Loopback;
 
         /// <summary>

--- a/Shared/IPUtils.cs
+++ b/Shared/IPUtils.cs
@@ -28,7 +28,7 @@ namespace Shared {
             var port = DefaultConfig.DEFAULT_SERVER_PORT;
 
             // Attempt to parse the port if provided.
-            var portIsInvalid = receivedEndpoint.Length > 1 && !short.TryParse(receivedEndpoint[1], out port);
+            var portIsInvalid = receivedEndpoint.Length > 1 && !ushort.TryParse(receivedEndpoint[1], out port);
 
             // If the port is invalid or the IP address is invalid,
             // abort and report the error.

--- a/Tests/TestClient/TestArgumentParsing.cs
+++ b/Tests/TestClient/TestArgumentParsing.cs
@@ -95,8 +95,8 @@ namespace Tests.TestClient {
         /// </summary>
         [TestCase]
         public void Test_ParseArgs_WithValidData() {
-            var expectedEndPoint = new IPEndPoint(IPAddress.Loopback, 5000);
-            ClientProgram.ParseArgs(new []{"127.0.0.1:5000"}, out var serverEndpoint);
+            var expectedEndPoint = new IPEndPoint(IPAddress.Loopback, 64000);
+            ClientProgram.ParseArgs(new []{"127.0.0.1:64000"}, out var serverEndpoint);
             Assert.AreEqual(serverEndpoint, expectedEndPoint);
         }
 

--- a/Tests/TestServer/TestEvents.cs
+++ b/Tests/TestServer/TestEvents.cs
@@ -58,7 +58,7 @@ namespace Tests.TestServer {
             Console.SetOut(this._textWriter);
 
             // Create a new server room
-            this._serverRoom = new ServerRoom("TestRoom");
+            this._serverRoom = new ServerRoom();
 
             // The message to store
             this._chatMessage = new ChatMessage(

--- a/Tests/TestServer/TestEvents.cs
+++ b/Tests/TestServer/TestEvents.cs
@@ -58,7 +58,7 @@ namespace Tests.TestServer {
             Console.SetOut(this._textWriter);
 
             // Create a new server room
-            this._serverRoom = new ServerRoom();
+            this._serverRoom = new ServerRoom("TestRoom");
 
             // The message to store
             this._chatMessage = new ChatMessage(

--- a/Tests/TestShared/TestIPUtils.cs
+++ b/Tests/TestShared/TestIPUtils.cs
@@ -16,7 +16,7 @@ namespace Tests.TestShared {
         [TestCase("62.0.0.2", "62.0.0.2", DefaultConfig.DEFAULT_SERVER_PORT)]
         [TestCase("127.0.0.1:5000", "127.0.0.1", 5000)]
         public void Test_TryParseEndpoint_withValidData(
-            string inputString, string expectedIP, short expectedPort) {
+            string inputString, string expectedIP, ushort expectedPort) {
 
             // Parse the input string
             var isParseSuccess =

--- a/Tests/TestShared/TestIPUtils.cs
+++ b/Tests/TestShared/TestIPUtils.cs
@@ -14,7 +14,7 @@ namespace Tests.TestShared {
         /// <param name="expectedIP">The expected IP to be found</param>
         /// <param name="expectedPort">The expected port to be found</param>
         [TestCase("62.0.0.2", "62.0.0.2", DefaultConfig.DEFAULT_SERVER_PORT)]
-        [TestCase("127.0.0.1:5000", "127.0.0.1", 5000)]
+        [TestCase("127.0.0.1:5000", "127.0.0.1", (ushort)5000)]
         public void Test_TryParseEndpoint_withValidData(
             string inputString, string expectedIP, ushort expectedPort) {
 

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RuntimeFrameworkVersion>2.1.4</RuntimeFrameworkVersion>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -10,6 +11,10 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="nunit" Version="3.10.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETCore.App" Version="2.1.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Implemented the below commands:

  | Command      | Description  |
  |--------------|--------------|
  | `QUIT      ` | Closes the client (client command). |
  | `HELP      ` | Retrieve the list of available commands (client command). |
  | `EXIT      ` | Closes and removes the current server room's connection. |
  | `CREATEROOM` | Creates a new room in a given server, which opens a new port. |
  | `LISTROOMS ` | Lists the available rooms of the currently connected server (see the `CONNECT` command).             |
  | `CONNECT   ` | Connect to a given `IP[:port]` combination. |
  
- Refactored the static server for an instantiable server class, 
  allowing more flexibility;
- Fixed a bug where if the client's listening `IPEndpoint` 
  was set to a non-routable IP, it would crash 
  (fixes [#9](https://github.com/NyanKiyoshi/iutrs-topiscuss/issues/9)).